### PR TITLE
@atomic-reactor/reactium-api@2.0.3

### DIFF
--- a/reactium_modules/@atomic-reactor/reactium-api/package.json
+++ b/reactium_modules/@atomic-reactor/reactium-api/package.json
@@ -6,7 +6,7 @@
     "version": "4.0.2"
   },
   "name": "@atomic-reactor/reactium-api",
-  "version": "1.0.2",
+  "version": "2.0.3",
   "description": "API bindings for Reactium framework",
   "author": "Reactium LLC",
   "license": "MIT",

--- a/reactium_modules/@atomic-reactor/reactium-api/sdk/actinium/index.js
+++ b/reactium_modules/@atomic-reactor/reactium-api/sdk/actinium/index.js
@@ -1,5 +1,4 @@
 import { isBrowserWindow } from '@atomic-reactor/reactium-sdk-core';
-import { io } from 'socket.io-client';
 import apiConfig from './config';
 
 let Actinium = null;
@@ -35,6 +34,9 @@ if (Actinium) {
     // Configure LiveQuery
     if (isBrowserWindow()) {
         const { host, protocol } = location;
+
+        // on windows, this compiles incorrectly, so use the distribution version
+        const { io } = require('socket.io-client/dist/socket.io');
 
         // proxied through express
         let ioURL = `${protocol}//${host}${restAPI}`;


### PR DESCRIPTION
@atomic-reactor/reactium-api@2.0.3. Fixes broken Windows compile of socker.io-client. Using distribution UMD bundle instead.