### PR TITLE
@atomic-reactor/reactium-api@5.0.2 fixes UMD import of socket.io-clie…

### DIFF
--- a/reactium_modules/@atomic-reactor/reactium-api/package.json
+++ b/reactium_modules/@atomic-reactor/reactium-api/package.json
@@ -6,13 +6,13 @@
     "version": "5.0.0"
   },
   "name": "@atomic-reactor/reactium-api",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "API bindings for Reactium framework",
   "author": "Reactium LLC",
   "license": "MIT",
   "dependencies": {
     "http-proxy-middleware": "^0.20.0",
     "parse": "^3.4.0",
-    "socket.io-client": "^4.4.0"
+    "socket.io-client": "^4.6.1"
   }
 }

--- a/reactium_modules/@atomic-reactor/reactium-api/sdk/actinium/index.js
+++ b/reactium_modules/@atomic-reactor/reactium-api/sdk/actinium/index.js
@@ -17,7 +17,9 @@ if (Actinium) {
     const { host, protocol } = location;
 
     // on windows, this compiles incorrectly, so use the distribution version
-    const { io } = require('socket.io-client/dist/socket.io.js');
+    // Recently, this stopped working on Mac too, and the default "export" from UMD should
+    // work.
+    const io = require('socket.io-client/dist/socket.io.js');
 
     // proxied through express
     let ioURL = `${protocol}//${host}${restAPI}`;


### PR DESCRIPTION
…nt (again)